### PR TITLE
Fix dependency to vulnerable version of Hoek

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/rtfeldman/binstall#readme",
   "dependencies": {
-    "request": "2.79.0",
+    "request": "2.83.0",
     "tar": "2.2.1"
   }
 }


### PR DESCRIPTION
Dependency tree for Request 2.79.0 includes Hoek 2.16.3 which is
vulnerable to following issue: https://hackerone.com/reports/310439

Upgrading Request to 2.83.0 will include patched version of Hoek.